### PR TITLE
made the improvements in spacing

### DIFF
--- a/components/Body.tsx
+++ b/components/Body.tsx
@@ -264,7 +264,7 @@ const Body: React.FC<BodyProps> = ({ sectionRefs, sections }) => {
           transition={{ duration: 0.8, delay: 0.6 }}
           className="space-y-8 sm:space-y-12 relative z-30"
         >
-          <div className="space-y-4 mt-8 sm:mt-12 lg:mt-20 text-center text-lg sm:text-xl md:text-2xl font-semibold text-white">
+          <div className="space-y-4 mt-8 sm:mt-110 lg:mt-110 text-center text-lg sm:text-xl md:text-2xl font-semibold text-white">
             <h3 className="text-2xl sm:text-3xl md:text-4xl font-bold text-white">
               Community{" "}
               <span className="text-transparent bg-clip-text bg-gradient-to-r from-orange-400 to-purple-400">

--- a/components/Features.tsx
+++ b/components/Features.tsx
@@ -64,7 +64,7 @@ const Features: React.FC = () => {
         initial={{ opacity: 0, y: 30 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.8, delay: 0.4 }}
-        className=" sm:space-y-12  sm:py-16 relative"
+        className=" sm:space-y-12  sm:py-16 sm:mt-70 relative"
       >
         {/* Decorative elements */}
         <div className="absolute top-0 right-0 w-40 h-40 bg-green-500/10 rounded-full blur-3xl"></div>


### PR DESCRIPTION
The spacing is properly aligned so that the contents do not overlap with each other and also responsiveness is maintained for any screens.
<img width="1883" height="871" alt="image" src="https://github.com/user-attachments/assets/9cb5ca82-e06b-4c20-87ac-d008355249a0" />

<img width="1874" height="863" alt="image" src="https://github.com/user-attachments/assets/ef5f1ca1-854f-419a-a872-15b0392750e5" />
Please @Heisen47 check and merge the PR and add the hactoberfest label along with the level of contribution. Let me know if require any changes.
fixes #118 
